### PR TITLE
Fix archive_org icon "exists"

### DIFF
--- a/archivebox/index/html.py
+++ b/archivebox/index/html.py
@@ -177,7 +177,7 @@ def snapshot_icons(snapshot) -> str:
                 # The check for archive_org is different, so it has to be handled separately
 
                 # get from db (faster)
-                exists = extractor_outputs[extractor] and extractor_outputs[extractor].status == 'succeeded' and extractor_outputs[extractor].output
+                exists = extractor in extractor_outputs and extractor_outputs[extractor] and extractor_outputs[extractor].status == 'succeeded' and extractor_outputs[extractor].output
                 # get from filesystem (slower)
                 # target_path = Path(path) / "archive.org.txt"
                 # exists = target_path.exists()


### PR DESCRIPTION
<!-- IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes. -->

# Summary

This PR fixes a bug where if you make a snapshot while SAVE_ARCHIVE_DOT_ORG is enabled then the archive_org link will always show as active, despite that being explicitly disabled. This is because of a miscalculation of the "exists" variable which ends up being set to "None" instead of "False". Screenshot included showing this -- it should have class="exists-False" but it's class="exists-None".
![20230815_23h24m43s_grim](https://github.com/DanielBatteryStapler/ArchiveBox/assets/10569817/0fb5649e-e7d2-477a-a22f-39455407ec54)
# Related issues

I didn't make an issue for this as when I noticed the problem I just fixed it instead of reporting anything.

# Changes these areas

- [X] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk

Let me know if there's anything I could do to help get this merged.